### PR TITLE
SCC-2195/ oauth refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.0
+
+Add in OAuth re-authentication, up to three successive attempts, for 401 response from Sierra API for an authenticated request.
+
 ## v1.0.3
 
 Fix: Critical bugs in initializer
@@ -16,4 +20,3 @@ Fix: Rename core library to match gem name for consistent `require`
 
 Initial push with support for:
  - Arbitrary GET and POST requests
-

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Because of the variety of HTTP status codes and "Content-Type"s returned by the 
 
 In the spirit of agnostism, the client will not intentionally raise an error when it encounters an error HTTP status code. Client will only raise an error when the request could not be carried out as specified and should be retried, that is:
  - Network failure
- - Invalid token error (401)
+ - Invalid token error (401) once maximum retry attempts met
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple client for querying the Sierra API
 
 ## Version
 
-> 1.0.3
+> 1.1.0
 
 ## Using
 
@@ -58,7 +58,7 @@ Because of the variety of HTTP status codes and "Content-Type"s returned by the 
 
 In the spirit of agnostism, the client will not intentionally raise an error when it encounters an error HTTP status code. Client will only raise an error when the request could not be carried out as specified and should be retried, that is:
  - Network failure
- - Invalid token error (401) once maximum retry attempts met
+ - Invalid token error (401) once maximum (3) retry attempts met
 
 ## Contributing
 

--- a/lib/nypl_sierra_api_client.rb
+++ b/lib/nypl_sierra_api_client.rb
@@ -99,7 +99,7 @@ class SierraApiClient
         if options[:authenticated]
           logger.debug "SierraApiClient: Refreshing oauth token for 401", { code: 401, body: response.body, retry: @retries }
 
-          return reauthorize_and_reattempt request, options
+          return reauthenticate_and_reattempt request, options
         end
       else
         retries_exceeded = true
@@ -114,7 +114,7 @@ class SierraApiClient
     SierraApiResponse.new(response)
   end
 
-  def reauthorize_and_reattempt request, options
+  def reauthenticate_and_reattempt request, options
     @retries += 1
     authenticate!
     # Reset bearer token header

--- a/lib/nypl_sierra_api_client.rb
+++ b/lib/nypl_sierra_api_client.rb
@@ -85,6 +85,7 @@ class SierraApiClient
       # TODO: Implement token refresh
       @access_token = nil
       logger.debug "SierraApiClient: Refereshing oauth token for 401", { code: 401, body: response.body }
+
       reattempt request
     end
 
@@ -97,8 +98,7 @@ class SierraApiClient
     http.use_ssl = @uri.scheme === 'https'
 
     begin
-      response = http.request(request)
-      return response
+      return http.request(request)
     rescue => e
       raise SierraApiClientError.new(e), "Failed to #{method} to #{path}: #{e.message}"
     end
@@ -108,7 +108,10 @@ class SierraApiClient
     raise SierraApiClientError.new("Maximum retries exceeded") if @retries >= 3
 
     authenticate!
+    # Reset bearer token header
+    request['Authorization'] = "Bearer #{@access_token}"
     @retries += 1
+
     execute request
   end
 

--- a/nypl_sierra_api_client.gemspec
+++ b/nypl_sierra_api_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'nypl_sierra_api_client'
-  s.version     = '1.0.3'
+  s.version     = '1.1.0'
   s.date        = '2020-04-21'
   s.summary     = "NYPL Sierra API client"
   s.description = "Client for querying Sierra API"

--- a/spec/sierra_api_client_spec.rb
+++ b/spec/sierra_api_client_spec.rb
@@ -252,11 +252,12 @@ describe SierraApiClient do
       client = SierraApiClient.new
       first_token = client.instance_variable_get(:@access_token)
 
-      client.get('one-reattempt')
+      resp = client.get('one-reattempt')
       second_token = client.instance_variable_get(:@access_token)
 
       expect(first_token).not_to eq(second_token)
       expect(client.instance_variable_get(:@retries)).to eq(0)
+      expect(resp).to be_a(SierraApiResponse)
     end
 
     it "should throw error once maximum retries attempted" do

--- a/spec/sierra_api_client_spec.rb
+++ b/spec/sierra_api_client_spec.rb
@@ -271,16 +271,5 @@ describe SierraApiClient do
       )
       expect(client.instance_variable_get(:@retries)).to eq(0)
     end
-
-    it "should throw error once maximum retries attempted" do
-      client = SierraApiClient.new
-      expect { client.get('maximum-attempts-path', { authenticated: false }) }.to raise_error(SierraApiClientTokenError)
-      assert_requested(
-        :get,
-        "#{ENV['SIERRA_API_BASE_URL']}maximum-attempts-path",
-        times: 1
-      )
-      expect(client.instance_variable_get(:@retries)).to eq(0)
-    end
   end
 end

--- a/spec/sierra_api_client_spec.rb
+++ b/spec/sierra_api_client_spec.rb
@@ -113,7 +113,7 @@ describe SierraApiClient do
       expect(options[:headers]['X-My-Header']).to eq('header value')
     end
   end
-  
+
   describe :authentication do
 
     it "should authenticate by default" do
@@ -211,9 +211,9 @@ describe SierraApiClient do
       expect(JSON.parse(resp.body)['foo']).to eq('bar')
     end
 
-    it "should consider 401 as error" do
+    it "should refresh oauth token for 401" do
       stub_request(:get, "#{ENV['SIERRA_API_BASE_URL']}some-path").to_return(status: 401, body: '{ "foo": "bar" }' )
-      expect { SierraApiClient.new.get('some-path') }.to raise_error(SierraApiClientTokenError)
+      expect { SierraApiClient.new.get('some-path') }.not_to raise_error(SierraApiClientTokenError)
     end
 
     it "should throw SierraApiClientError if response is not valid json" do

--- a/spec/sierra_api_client_spec.rb
+++ b/spec/sierra_api_client_spec.rb
@@ -258,12 +258,29 @@ describe SierraApiClient do
       expect(first_token).not_to eq(second_token)
       expect(client.instance_variable_get(:@retries)).to eq(0)
       expect(resp).to be_a(SierraApiResponse)
+      expect(resp.code).to eq(200)
     end
 
     it "should throw error once maximum retries attempted" do
       client = SierraApiClient.new
       expect { client.get('maximum-attempts-path') }.to raise_error(SierraApiClientTokenError)
-      expect(client.instance_variable_get(:@retries)).to eq(3)
+      assert_requested(
+        :get,
+        "#{ENV['SIERRA_API_BASE_URL']}maximum-attempts-path",
+        times: 4
+      )
+      expect(client.instance_variable_get(:@retries)).to eq(0)
+    end
+
+    it "should throw error once maximum retries attempted" do
+      client = SierraApiClient.new
+      expect { client.get('maximum-attempts-path', { authenticated: false }) }.to raise_error(SierraApiClientTokenError)
+      assert_requested(
+        :get,
+        "#{ENV['SIERRA_API_BASE_URL']}maximum-attempts-path",
+        times: 1
+      )
+      expect(client.instance_variable_get(:@retries)).to eq(0)
     end
   end
 end


### PR DESCRIPTION
This PR introduces oauth refreshing, with a maximum of three re-authentications. This is somewhat of an big code refactor.

Now, 
1. `do_request` passes the request to `execute`. 
2. `execute` will make the HTTP request, pass the response and the request to `handle_response` (previously `parse_response`). 
3. `handle_response` will pass the request to `reattempt` for a response with 401 status code, otherwise it returns a `SierraApiResponse`. 
4. `reattempt` is basically a wrapper for `authenticate` + `execute`. Therefore, repeating 2+3