### PR TITLE
Scc 2983 Improve auth and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## v1.1.0
+## v1.3.0
+
+Add reattempted requests with exponential backoff, logging, and erroring for empty responses from Sierra
+Add exponential backoff for authentication reattempts
+
+## v1.2.0
 
 Add PUT and DELETE functionality 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple client for querying the Sierra API
 
 ## Version
 
-> 1.2.0
+> 1.3.0
 
 ## Using
 

--- a/lib/nypl_sierra_api_client.rb
+++ b/lib/nypl_sierra_api_client.rb
@@ -131,8 +131,11 @@ class SierraApiClient
     SierraApiResponse.new(response)
   end
 
+
+
   def reauthenticate_and_reattempt request, options
     @retries += 1
+    sleep 2 ** (retries - 1)
     authenticate!
     # Reset bearer token header
     request['Authorization'] = "Bearer #{@access_token}"

--- a/lib/nypl_sierra_api_client.rb
+++ b/lib/nypl_sierra_api_client.rb
@@ -138,7 +138,7 @@ class SierraApiClient
 
   def reattempt_request request, options 
     if @retries < 3
-      logger.warn "request retry ##{@retries} due to empty response from Sierra API"
+      logger.warn "#{request.method} request retry ##{@retries} due to empty response from Sierra API"
       sleep 2 ** (@retries - 1)
       @retries += 1
       execute request, options

--- a/nypl_sierra_api_client.gemspec
+++ b/nypl_sierra_api_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'nypl_sierra_api_client'
-  s.version     = '1.2.0'
+  s.version     = '1.3.0'
   s.date        = '2020-04-21'
   s.summary     = "NYPL Sierra API client"
   s.description = "Client for querying Sierra API"


### PR DESCRIPTION
These were the specified changes in the ticket, but some of the work was already done

** Should reuse access tokens up to some age or until token is found to be invalid
** Should retry auth some number of times (say, 3)
- exponential backoff on auth retry
- Should retry data fetches some number of times (say, 3) with exponential backoff
- Should detect "end of file" (0 byte response) from Sierra and retry as noted above
- Logs should capture any number of retries and when we get an empty response

I added a new method called reattempt_request that is called on the conditions that describe an empty sierra response, and added exponential backoff to the already implemented auth retry.